### PR TITLE
Remove anonymous fns

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ The `:if` entry can be:
   the predicate (a predicate is a module that implements the `Unplug.Predicate` behavior).
 - A module that implements the `Unplug.Predicate` behavior. Without any predicate options being specified, an
   empty list is sent as the second argument to the predicate's `call/2` function.
-- An anonymous function of arity one. That one argument being the `conn` for the current request.
 
 The `:do` entry can be:
 
@@ -76,23 +75,18 @@ The `:do` entry can be:
   predicate, and the second element being options that you want to send to that plug.
 - A plug module that you want to execute upon a truthy value from the predicate. Without any options specified,
   Unplug will assume that an empty list should be sent to the plug's `init/1` function.
-- An anonymous function that takes one argument, with that argument being the current request's `conn`. This
-  function must also return a `Plug.Conn` struct.
 
 There is also an `:else` entry that can be provided to `Unplug`. The `:else` entry is identical to the `:do` entry
 in terms of what it accepts as valid input. The `:else` entry is what is execute if the `:if` entry yields a falsey
 value for the current request.
 
-Another example to show off the anonymous function and `:else` functionality could be something like this:
+An example to show off the `:else` functionality could be something like this:
 
 ```elixir
 plug Unplug,
-  if: fn conn -> conn.remote_ip == {10, 0, 0, 1} end,
+  if: MyCoolApp.WhiteListedIPAddress,
   do: MyCoolApp.MetricsExporter,
-  else: fn conn ->
-    Logger.warn("Someone is trying to steal my metrics!")
-    conn
-  end,
+  else: MyCoolApp.LogWarning
 ```
 
 If the above example, we only want to expose our Prometheus metrics if the request is coming from a known safe source

--- a/lib/unplug.ex
+++ b/lib/unplug.ex
@@ -96,17 +96,14 @@ defmodule Unplug do
 
   defp eval_plug_init(:compile, :skip), do: :skip
   defp eval_plug_init(:compile, {plug, opts}), do: plug.init(opts)
-  defp eval_plug_init(:compile, plug) when is_function(plug, 1), do: nil
   defp eval_plug_init(:compile, plug), do: plug.init([])
   defp eval_plug_init(:runtime, :skip), do: :skip
   defp eval_plug_init(:runtime, _plug), do: nil
   defp eval_plug_init(bad_arg, _plug), do: raise("Invalid value #{inspect(bad_arg)} for Unplug config :init_mode")
 
-  defp exec_if_condition_call(conn, predicate) when is_function(predicate, 1), do: predicate.(conn)
   defp exec_if_condition_call(conn, {predicate_module, predicate_opts}), do: predicate_module.call(conn, predicate_opts)
   defp exec_if_condition_call(conn, predicate_module), do: predicate_module.call(conn, [])
 
-  defp exec_plug_call(conn, function, _plug_opts) when is_function(function, 1), do: function.(conn)
   defp exec_plug_call(conn, {plug_module, _init_opts}, plug_opts), do: plug_module.call(conn, plug_opts)
   defp exec_plug_call(conn, plug_module, plug_opts), do: plug_module.call(conn, plug_opts)
 end

--- a/test/unplug_test.exs
+++ b/test/unplug_test.exs
@@ -179,29 +179,5 @@ defmodule UnplugTest do
 
       assert conn.assigns == %{other: "setting"}
     end
-
-    test "should accept anonymous functions for if/do/else" do
-      opts =
-        Unplug.init(
-          if: fn c -> c.assigns[:thing] == "nice" end,
-          do: fn c -> assign(c, :cool, "it's good") end,
-          else: fn c -> assign(c, :no, "it's bad") end
-        )
-
-      conn =
-        :get
-        |> conn("/")
-        |> Unplug.call(opts)
-
-      assert conn.assigns == %{no: "it's bad"}
-
-      conn =
-        :get
-        |> conn("/")
-        |> assign(:thing, "nice")
-        |> Unplug.call(opts)
-
-      assert conn.assigns == %{cool: "it's good", thing: "nice"}
-    end
   end
 end


### PR DESCRIPTION
My bad.  `plug` adds plugs to the module attributes and you can't store anonymous functions as module attributes